### PR TITLE
Specify compatible version for Swift SDK in Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "watson-developer-cloud/swift-sdk"
+github "watson-developer-cloud/swift-sdk" ~> 1.0.0


### PR DESCRIPTION
This PR modifies the Cartfile to specify that the Watson Swift SDK must be a compatible version with Release 1.0.0.  Forcing the version to be compatible will prevent the sample from breaking when a new major version of the Swift SDK is released.